### PR TITLE
Add SAP security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+<!-- START SAP SECURITY.MD V0.0.1 BLOCK -->
+<!-- Please do not remove the version header, this is needed for automatic updates of the SECURITY.md -->
+# SAP Open Source Security Policy
+
+SAP takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, including our primary [SAP](https://github.com/SAP), [SAP-docs](https://github.com/SAP-docs) organizations as well as [our other GitHub organizations and projects](https://opensource.sap.com).
+
+If you believe you have found a security vulnerability in any SAP-owned repository, please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them via the SAP Trust Center at [https://www.sap.com/about/trust-center/security/incident-management.html](https://www.sap.com/about/trust-center/security/incident-management.html).
+
+If you prefer to submit via email, please send an email to [secure@sap.com](mailto:secure@sap.com). If possible, encrypt your message with our PGP key; please download it from the [SAP Trust Center](https://www.sap.com/dmc/policies/pgp/keyblock.txt).
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  - The repository name or URL
+  - Type of issue (buffer overflow, SQL injection, cross-site scripting, etc.)
+  - Full paths of the source file(s) related to the manifestation of the issue
+  - The location of the affected source code (tag/branch/commit or direct URL)
+  - Any particular configuration required to reproduce the issue
+  - Step-by-step instructions to reproduce the issue
+  - Proof-of-concept or exploit code (if possible)
+  - Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Disclosure Guidelines
+
+We like to ask you to follow the [Disclosure Guidelines for SAP Security Advisories](https://www.sap.com/documents/2022/02/9ccd9ca0-167e-0010-bca6-c68f7e60039b.html).
+
+## SAP Internal Response Process
+
+As an SAP employee, please check our internal open source security response process ([go/oss-security-response](https://go.sap.corp/oss-security-response)) for further details on how to handle security incidents.
+
+<!-- END SAP SECURITY.MD V0.0.1 BLOCK -->


### PR DESCRIPTION
This PR adds the default SAP security policy from https://github.com/SAP/.github/blob/main/SECURITY.md to the Open Component Model `community` repository. 

This documents the default process how externals should report vulnerabilities for any SAP related open source project. 

In addition I would recommend to rename this repository from `community` to `.github`. The [`.github` repository is a special repository, which hosts community default files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) (e.g. CODE_OF_CONDUCT.md/SECURITY.md) which will be displayed in all repositories inside the organization.     